### PR TITLE
Contributors should use common settings in VSCode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_sie = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+[*.{md,yml}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Modern IDEs use different settings. In this project,
all the maintainers are using heavily VSCode.
As a result it makes sense to use the same,
configurations when it comes on doing many things
related to syntax.

User should install the following extention:

  - https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

This PR Fixes: #18