### PR TITLE
Minor fixes and adding missing workflow file

### DIFF
--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -1,0 +1,27 @@
+name: goreleaser
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,11 @@
 # .goreleaser.yml proposed options for Romie
 builds:
   # You can have multiple builds defined as a yaml list
-  - main: /main.go
+  - main: main.go
     id: "romie"
-    dir: go
-    binary: main
+    dir: .
+    binary: romie
+
     goos:
       - linux
       - darwin


### PR DESCRIPTION
After testing the .goreleaser.yml config file, I hade to do some teaks and ad the missing github action workflow.
Now whenever we do a release (aka tag) it will trigger the build and attach the binaries.

See my test release https://github.com/cerebrux/romie/releases/tag/1.0

