### PR TITLE
Build multi-platform bins for Linux, Mac Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,10 +8,27 @@ builds:
       - windows
       - freebsd
       - openbsd
+      - netbsd
+      - dragonfly
     goarch:
       - 386
       - amd64
       - arm
       - arm64
+    ignore:
+      - goos: darwin
+        goarch: 386, arm
+      - goos: windows
+        goarch: arm, arm64
+      - goos: freebsd
+        goarch: arm64
+      - goos: netbsd
+        goarch: arm64
+      - goos: dragonfly
+        goarch: 386, arm, arm64
+    goarm:
+      - 6
+      - 7
+    mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser


### PR DESCRIPTION
1. Added missing "popular" BSD OSes (dragonfly and netbsd)
2. Added arm6 and arm7 binaries
3. Added modified timestamp on the output binary to ensure a build was reproducible (see: https://goreleaser.com/customization/build/)
4. Added ignore section, for architecture that are not supported by Go in
combination with the $goos (see https://golang.org/doc/install/source#environment)

Fixes #13
Fixes #15