### PR TITLE
ci: add semantic.yml for semantic commits

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,13 @@
+titleOnly: true
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert


### PR DESCRIPTION
Addition of a yml file in .github/workflows in order to configure how commits should be phrased.

Current configuration:

1) ALL commits should always be semantic. Valid tokens are:
  - feat
  - fix
  - docs
  - style
  - refactor
  - perf
  - test
  - build
  - ci
  - chore
  - revert
2) PR titles can be or not be semantic. No rules for them. 
3) **merge:** and **revert:** commits are allowed too.

Closes #22