### PR TITLE
👷 ci: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Configuration options for dependency updates
 # See: https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
-#
+
 version: 2
 updates:
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Configuration options for dependency updates
+# See: https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+#
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci:"
+
+  # Maintain Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci:"


### PR DESCRIPTION
Add [dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates) config.
Automate gh-actions and go mod dependencies updates on a weekly-basis.

As mentioned in #7 and #57
