### PR TITLE
👷 ci: Add mergify configuration, to automatically merge PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+pull_request_rules:
+  - name: Automatic merge for master when reviewed and CI passes
+    conditions:
+      - check-success=validate_goreleaser
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - base=master
+      - label!=Do not merge
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        priority: medium
+
+  - name: Automatic merge for Dependabot pull requests (low priority)
+    conditions:
+      - author~=^dependabot\[bot\]$
+      - check-success=validate_goreleaser
+      - "#approved-reviews-by>=1"
+      - label!=Do not merge
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        priority: low
+
+  - name: Remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews: {}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,14 +16,13 @@ pull_request_rules:
     conditions:
       - author~=^dependabot\[bot\]$
       - check-success=validate_goreleaser
-      - "#approved-reviews-by>=1"
       - label!=Do not merge
     actions:
       review:
         type: APPROVE
       merge:
         method: squash
-        strict: smart+fasttrack
+        strict: false
         priority: low
 
   - name: Remove outdated reviews


### PR DESCRIPTION
Adds 3 mergify "configs"

1. PRs to master branch with 2 approvals and no changes requested, will be squashed and merged when checks are successful, with medium priority and will update local branch with master if needed. Merge will be skipped if Label "Do not merge" is applied.
2. PRs to master branch by dependabot will be approved automatically and then squashed and merged with the lowest priority. Merge will be skipped if Label "Do not merge" is applied.
3. Removes outdated reviews; approvals/requested changes will be dismissed as stale, if new commits are added to a PR, requiring approval again.

Closes #23
Mutually exclusive with #73