### PR TITLE
👷 ci: Add kodiak configuration, to automatically merge PRs

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,21 @@
+version = 1
+
+[merge]
+# Attempt to merge any PR that passes all GitHub branch protection requirements
+require_automerge_label = false
+# Do not merge a PR with any of these labels
+blocking_labels = ["wip", "Do not merge"]
+# COnfigure merge PR method be be squash & merge
+method = "squash"
+
+[merge.message]
+# Use PR title for the merge commit
+title = "pull_request_title"
+# Use PR body for the merge commit
+body = "pull_request_body"
+# Remove html comments to auto remove PR templates
+strip_html_comments = true
+
+[approve]
+# Automatically approve Dependabot pull requests
+auto_approve_usernames = ["dependabot"]


### PR DESCRIPTION
Adds kodiak configuration:

- Will auto approve dependabot PRs
- Will squash and merge PRs that pass the branch restriction protections

> Compared to Mergify, this is less flexible/configurable. Especially the hybrid rule, about number of reviewers to be different if the PR is originated by dependabot, is not possible with kodiak.

Closes #23
Mutually exclusive with #72