### PR TITLE
feat: Add util FolderExists with runnable Example and Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.idea/
 coverage.txt
 romie
 bin/goreleaser

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,5 @@ linters:
     - gofumpt
     - gci
     - nlreturn
+    - testpackage
+    - gochecknoglobals

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.32.0
 	github.com/sirupsen/logrus v1.7.0
+	github.com/spf13/afero v1.1.2
 	golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752
 )

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module romie
+module github.com/romie-gr/romie
 
 go 1.15
 
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.32.0
+	github.com/sirupsen/logrus v1.7.0
 	golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752
 )

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 )
-
-var appFs = &afero.Afero{Fs: afero.NewOsFs()}
 
 // FolderExists reports whether the provided directory exists.
 func FolderExists(path string) bool {
@@ -16,7 +13,7 @@ func FolderExists(path string) bool {
 		return false
 	}
 
-	exists, err := appFs.DirExists(path)
+	exists, err := AppFS.DirExists(path)
 	if err != nil {
 		log.Debug(fmt.Printf("Error: %s", err.Error()))
 		return false

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-var AppFs = &afero.Afero{Fs: afero.NewOsFs()}
+var appFs = &afero.Afero{Fs: afero.NewOsFs()}
 
 // FolderExists reports whether the provided directory exists.
 func FolderExists(path string) bool {
@@ -16,7 +16,7 @@ func FolderExists(path string) bool {
 		return false
 	}
 
-	exists, err := AppFs.DirExists(path)
+	exists, err := appFs.DirExists(path)
 	if err != nil {
 		log.Debug(fmt.Printf("Error: %s", err.Error()))
 		return false

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -7,15 +7,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-var (
-	AppFs     afero.Fs
-	FSUtil *afero.Afero
-)
-
-func init() {
-	AppFs = afero.NewOsFs()
-	FSUtil = &afero.Afero{Fs: AppFs}
-}
+var AppFs = &afero.Afero{Fs: afero.NewOsFs()}
 
 // FolderExists reports whether the provided directory exists.
 func FolderExists(path string) bool {
@@ -24,7 +16,7 @@ func FolderExists(path string) bool {
 		return false
 	}
 
-	exists, err := FSUtil.DirExists(path)
+	exists, err := AppFs.DirExists(path)
 	if err != nil {
 		log.Debug(fmt.Printf("Error: %s", err.Error()))
 		return false

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -1,10 +1,21 @@
 package utils
 
 import (
-	"os"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 )
+
+var (
+	AppFs     afero.Fs
+	FSUtil *afero.Afero
+)
+
+func init() {
+	AppFs = afero.NewOsFs()
+	FSUtil = &afero.Afero{Fs: AppFs}
+}
 
 // FolderExists reports whether the provided directory exists.
 func FolderExists(path string) bool {
@@ -13,13 +24,11 @@ func FolderExists(path string) bool {
 		return false
 	}
 
-	info, err := os.Stat(path)
+	exists, err := FSUtil.DirExists(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			log.Debug("Path does not exist")
-			return false
-		}
+		log.Debug(fmt.Printf("Error: %s", err.Error()))
+		return false
 	}
 
-	return info.IsDir()
+	return exists
 }

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// FolderExists reports whether the provided directory exists.
+func FolderExists(path string) bool {
+	if path == "" {
+		log.Debug("Path is empty")
+		return false
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Debug("Path does not exist")
+			return false
+		}
+	}
+
+	return info.IsDir()
+}

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -5,17 +5,8 @@ import (
 	"testing"
 
 	"github.com/romie-gr/romie/internal/utils"
-
 	"github.com/spf13/afero"
 )
-
-func init() {
-	utils.AppFs = afero.NewMemMapFs()
-	utils.FSUtil = &afero.Afero{Fs: utils.AppFs}
-
-	_ = utils.FSUtil.Mkdir("/a-folder-that-exists", 0755)
-	_, _ = utils.FSUtil.Create("/a-folder-that-exists/file.txt")
-}
 
 func ExampleFolderExists() {
 	exists := utils.FolderExists("/a-non-existing-folder")
@@ -28,6 +19,11 @@ func ExampleFolderExists() {
 }
 
 func TestFolderExists(t *testing.T) {
+	utils.AppFs = &afero.Afero{Fs: afero.NewMemMapFs()}
+
+	_ = utils.AppFs.Mkdir("/a-folder-that-exists", 0755)
+	_, _ = utils.AppFs.Create("/a-folder-that-exists/file.txt")
+
 	tests := []struct {
 		name string
 		path string

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -18,10 +18,10 @@ func ExampleFolderExists() {
 }
 
 func TestFolderExists(t *testing.T) {
-	appFs = &afero.Afero{Fs: afero.NewMemMapFs()}
+	AppFS = &afero.Afero{Fs: afero.NewMemMapFs()}
 
-	_ = appFs.Mkdir("/a-folder-that-exists", 0755)
-	_, _ = appFs.Create("/a-folder-that-exists/file.txt")
+	_ = AppFS.Mkdir("/a-folder-that-exists", 0755)
+	_, _ = AppFS.Create("/a-folder-that-exists/file.txt")
 
 	tests := []struct {
 		name string

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -1,15 +1,14 @@
-package utils_test
+package utils
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/romie-gr/romie/internal/utils"
 	"github.com/spf13/afero"
 )
 
 func ExampleFolderExists() {
-	exists := utils.FolderExists("/a-non-existing-folder")
+	exists := FolderExists("/a-non-existing-folder")
 	if exists {
 		fmt.Println("Folder exists")
 	} else {
@@ -19,10 +18,10 @@ func ExampleFolderExists() {
 }
 
 func TestFolderExists(t *testing.T) {
-	utils.AppFs = &afero.Afero{Fs: afero.NewMemMapFs()}
+	appFs = &afero.Afero{Fs: afero.NewMemMapFs()}
 
-	_ = utils.AppFs.Mkdir("/a-folder-that-exists", 0755)
-	_, _ = utils.AppFs.Create("/a-folder-that-exists/file.txt")
+	_ = appFs.Mkdir("/a-folder-that-exists", 0755)
+	_, _ = appFs.Create("/a-folder-that-exists/file.txt")
 
 	tests := []struct {
 		name string
@@ -53,7 +52,7 @@ func TestFolderExists(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if got := utils.FolderExists(tt.path); got != tt.want {
+			if got := FolderExists(tt.path); got != tt.want {
 				t.Errorf("FolderExists() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/spf13/afero"
 )
 
+var (
+	existingFolder    = "/a-folder-that-exists"
+	nonExistingFolder = "/a-folder-that-does-not-exist"
+	existingFile      = "/a-folder-that-exists/file.txt"
+)
+
 func ExampleFolderExists() {
 	exists := FolderExists("/a-non-existing-folder")
 	if exists {
@@ -20,8 +26,8 @@ func ExampleFolderExists() {
 func TestFolderExists(t *testing.T) {
 	AppFS = &afero.Afero{Fs: afero.NewMemMapFs()}
 
-	_ = AppFS.Mkdir("/a-folder-that-exists", 0755)
-	_, _ = AppFS.Create("/a-folder-that-exists/file.txt")
+	_ = AppFS.Mkdir(existingFolder, 0755)
+	_, _ = AppFS.Create(existingFile)
 
 	tests := []struct {
 		name string
@@ -30,17 +36,17 @@ func TestFolderExists(t *testing.T) {
 	}{
 		{
 			"Returns true when given folder exists",
-			"/a-folder-that-exists",
+			existingFolder,
 			true,
 		},
 		{
 			"Returns false when given folder does not exist",
-			"/a-folder-that-does-not-exist",
+			nonExistingFolder,
 			false,
 		},
 		{
 			"Returns false when provided path is not a directory",
-			"/a-folder-that-exists/file.txt",
+			existingFile,
 			false,
 		},
 		{

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -3,7 +3,17 @@ package utils
 import (
 	"fmt"
 	"testing"
+
+	"github.com/spf13/afero"
 )
+
+func init() {
+	AppFs = afero.NewMemMapFs()
+	FSUtil = &afero.Afero{Fs: AppFs}
+
+	_ = FSUtil.Mkdir("/a-folder-that-exists", 0755)
+	_, _ = FSUtil.Create("/a-folder-that-exists/file.txt")
+}
 
 func ExampleFolderExists() {
 	exists := FolderExists("/a-non-existing-folder")
@@ -23,17 +33,17 @@ func TestFolderExists(t *testing.T) {
 	}{
 		{
 			"Returns true when given folder exists",
-			"./testdata/a-folder-that-exists",
+			"/a-folder-that-exists",
 			true,
 		},
 		{
 			"Returns false when given folder does not exist",
-			"./testdata/a-folder-that-does-not-exist",
+			"/a-folder-that-does-not-exist",
 			false,
 		},
 		{
 			"Returns false when provided path is not a directory",
-			"./testdata/file.txt",
+			"/a-folder-that-exists/file.txt",
 			false,
 		},
 		{

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func ExampleFolderExists() {
+	exists := FolderExists("/a-non-existing-folder")
+	if exists {
+		fmt.Println("Folder exists")
+	} else {
+		fmt.Println("Folder does not exist")
+	}
+	// Output: Folder does not exist
+}
+
+func TestFolderExists(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			"Returns true when given folder exists",
+			"./testdata/a-folder-that-exists",
+			true,
+		},
+		{
+			"Returns false when given folder does not exist",
+			"./testdata/a-folder-that-does-not-exist",
+			false,
+		},
+		{
+			"Returns false when provided path is not a directory",
+			"./testdata/file.txt",
+			false,
+		},
+		{
+			"Returns false when provided path is empty",
+			"",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FolderExists(tt.path); got != tt.want {
+				t.Errorf("FolderExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -43,6 +43,7 @@ func TestFolderExists(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := FolderExists(tt.path); got != tt.want {
 				t.Errorf("FolderExists() = %v, want %v", got, tt.want)

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -1,22 +1,24 @@
-package utils
+package utils_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/romie-gr/romie/internal/utils"
+
 	"github.com/spf13/afero"
 )
 
 func init() {
-	AppFs = afero.NewMemMapFs()
-	FSUtil = &afero.Afero{Fs: AppFs}
+	utils.AppFs = afero.NewMemMapFs()
+	utils.FSUtil = &afero.Afero{Fs: utils.AppFs}
 
-	_ = FSUtil.Mkdir("/a-folder-that-exists", 0755)
-	_, _ = FSUtil.Create("/a-folder-that-exists/file.txt")
+	_ = utils.FSUtil.Mkdir("/a-folder-that-exists", 0755)
+	_, _ = utils.FSUtil.Create("/a-folder-that-exists/file.txt")
 }
 
 func ExampleFolderExists() {
-	exists := FolderExists("/a-non-existing-folder")
+	exists := utils.FolderExists("/a-non-existing-folder")
 	if exists {
 		fmt.Println("Folder exists")
 	} else {
@@ -55,7 +57,7 @@ func TestFolderExists(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FolderExists(tt.path); got != tt.want {
+			if got := utils.FolderExists(tt.path); got != tt.want {
 				t.Errorf("FolderExists() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -59,7 +59,7 @@ func TestFolderExists(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := FolderExists(tt.path); got != tt.want {
-				t.Errorf("FolderExists() = %v, want %v", got, tt.want)
+				t.Errorf("FolderExists(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/internal/utils/init.go
+++ b/internal/utils/init.go
@@ -1,0 +1,6 @@
+package utils
+
+import "github.com/spf13/afero"
+
+// AppFS Application filesystem.
+var AppFS = &afero.Afero{Fs: afero.NewOsFs()}


### PR DESCRIPTION
This PRs adds the first filesystem-related utility: `FolderExists`.

Method checks if folder exists and returns a boolean value.
No errors are reported, but logs using logrus, in case `os.IsNotExist` fails.

- has runnable Example
- has unit tests
- uses `afero` for filesystem abstraction

Closes #92