### PR TITLE
feat: Allow configuring debug log level for logrus using env var ROMIE_DEBUG

### DIFF
--- a/internal/utils/init.go
+++ b/internal/utils/init.go
@@ -1,6 +1,19 @@
 package utils
 
-import "github.com/spf13/afero"
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
 
 // AppFS Application filesystem.
 var AppFS = &afero.Afero{Fs: afero.NewOsFs()}
+
+func init() {
+	// Set debug mode on
+	if os.Getenv("ROMIE_DEBUG") == "on" {
+		// TODO: This is temporary. Remove it once Cobra/Viper is configured, to handle it as a boolean flags
+		log.SetLevel(log.DebugLevel)
+	}
+}

--- a/internal/utils/init.go
+++ b/internal/utils/init.go
@@ -13,7 +13,7 @@ var AppFS = &afero.Afero{Fs: afero.NewOsFs()}
 func init() {
 	// Set debug mode on
 	if os.Getenv("ROMIE_DEBUG") == "on" {
-		// TODO: This is temporary. Remove it once Cobra/Viper is configured, to handle it as a boolean flags
+		// See https://github.com/romie-gr/romie/issues/154
 		log.SetLevel(log.DebugLevel)
 	}
 }


### PR DESCRIPTION
Allow configuring debug log level for logrus using env var ROMIE_DEBUG

Example:

```bash
ROMIE_DEBUG=on go run main.go
```