### PR TITLE
feat: Check if connection can be established

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,5 @@ linters:
     - gochecknoinits
     - godot
     - exhaustivestruct
+    # https://github.com/golangci/golangci-lint/issues/541
+    - interfacer

--- a/internal/utils/network.go
+++ b/internal/utils/network.go
@@ -1,0 +1,31 @@
+//nolint:noctx
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+func IsOnline(url url.URL) (bool, error) {
+	timeout := 2 * time.Second
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(url.String())
+
+	if err != nil {
+		return false, fmt.Errorf("%w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, nil
+	}
+
+	// Non-200 http statuses are considered error
+	err = fmt.Errorf("timeout or uknown HTTP error, while trying to access %q", url.String())
+
+	return false, err
+}

--- a/internal/utils/network.go
+++ b/internal/utils/network.go
@@ -8,7 +8,8 @@ import (
 	"time"
 )
 
-func IsOnline(url url.URL) (bool, error) {
+// IsOnline checks the provided URL for connectivity
+func IsOnline(url url.URL) error {
 	timeout := 2 * time.Second
 	client := http.Client{
 		Timeout: timeout,
@@ -16,16 +17,14 @@ func IsOnline(url url.URL) (bool, error) {
 	resp, err := client.Get(url.String())
 
 	if err != nil {
-		return false, fmt.Errorf("%w", err)
+		return fmt.Errorf("%w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return true, nil
+		return nil
 	}
 
 	// Non-200 http statuses are considered error
-	err = fmt.Errorf("timeout or uknown HTTP error, while trying to access %q", url.String())
-
-	return false, err
+	return fmt.Errorf("timeout or uknown HTTP error, while trying to access %q", url.String())
 }

--- a/internal/utils/network_test.go
+++ b/internal/utils/network_test.go
@@ -12,13 +12,11 @@ import (
 
 func ExampleIsOnline() {
 	google, _ := url.Parse("https://google.com")
-	hostOK, err := IsOnline(*google)
+	err := IsOnline(*google)
 
 	if err != nil {
-		log.Error(err)
-	}
-
-	if hostOK {
+		fmt.Println("Host is not accessible")
+	} else {
 		fmt.Println("Host is accessible")
 	}
 	// Output: Host is accessible
@@ -63,49 +61,41 @@ func Test_IsOnline(t *testing.T) {
 	tests := []struct {
 		name     string
 		scenario string
-		hostOk   bool
 		wantErr  bool
 	}{
 		{
 			"Succeeds with 200",
 			"OK",
-			true,
 			false,
 		},
 		{
 			"Succeeds with other 200-code (202)",
 			"Accepted",
-			true,
 			false,
 		},
 		{
 			"Succeeds after following a redirect (301)",
 			"Redirect",
-			true,
 			false,
 		},
 		{
 			"Fails if page replies with not generic error (400)",
 			"BadRequest",
-			false,
 			true,
 		},
 		{
 			"Fails if page replies with not found error (404)",
 			"NotFound",
-			false,
 			true,
 		},
 		{
 			"Fails if page replies with too many requests error (429)",
 			"RateLimit",
-			false,
 			true,
 		},
 		{
 			"Fails if page replies with internal server error (500)",
 			"ServerError",
-			false,
 			true,
 		},
 	}
@@ -116,10 +106,7 @@ func Test_IsOnline(t *testing.T) {
 			defer ts.Close()
 			testURL, _ := url.Parse(ts.URL)
 
-			got, err := IsOnline(*testURL)
-			if got != tt.hostOk {
-				t.Errorf("IsOnline(%q) got = %v, want %v", testURL.String(), got, tt.hostOk)
-			}
+			err := IsOnline(*testURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsOnline(%q) error = %v, wantErr %v", testURL.String(), err, tt.wantErr)
 			}
@@ -130,11 +117,7 @@ func Test_IsOnline(t *testing.T) {
 func Test_IsOnline_MissingHost(t *testing.T) {
 	testURL, _ := url.Parse("https://does-not-exist.romie-gr.romie.com")
 
-	hostOk, err := IsOnline(*testURL)
-	if hostOk != false {
-		t.Errorf("IsOnline(%q) got = %v, want %v", testURL.String(), hostOk, false)
-	}
-
+	err := IsOnline(*testURL)
 	if (err != nil) != true {
 		t.Errorf("IsOnline(%q) error = %v, wantErr %v", testURL.String(), err, true)
 	}

--- a/internal/utils/network_test.go
+++ b/internal/utils/network_test.go
@@ -1,0 +1,141 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func ExampleIsOnline() {
+	google, _ := url.Parse("https://google.com")
+	hostOK, err := IsOnline(*google)
+
+	if err != nil {
+		log.Error(err)
+	}
+
+	if hostOK {
+		fmt.Println("Host is accessible")
+	}
+	// Output: Host is accessible
+}
+
+func setUpMock(scenario string) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch scenario {
+		case "OK":
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintln(w, "OK")
+			return
+		case "Accepted":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = fmt.Fprintln(w, "Accepted")
+			return
+		case "Redirect":
+			http.Redirect(w, r, "https://google.com", http.StatusMovedPermanently)
+			return
+		case "BadRequest":
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		case "NotFound":
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		case "RateLimit":
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		case "ServerError":
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusNotFound)
+			return
+		default:
+			log.Fatalf("Unimplemented scenario %q provided", scenario)
+			return
+		}
+	}))
+
+	return ts
+}
+
+func Test_IsOnline(t *testing.T) {
+	tests := []struct {
+		name     string
+		scenario string
+		hostOk   bool
+		wantErr  bool
+	}{
+		{
+			"Succeeds with 200",
+			"OK",
+			true,
+			false,
+		},
+		{
+			"Succeeds with other 200-code (202)",
+			"Accepted",
+			true,
+			false,
+		},
+		{
+			"Succeeds after following a redirect (301)",
+			"Redirect",
+			true,
+			false,
+		},
+		{
+			"Fails if page replies with not generic error (400)",
+			"BadRequest",
+			false,
+			true,
+		},
+		{
+			"Fails if page replies with not found error (404)",
+			"NotFound",
+			false,
+			true,
+		},
+		{
+			"Fails if page replies with too many requests error (429)",
+			"RateLimit",
+			false,
+			true,
+		},
+		{
+			"Fails if page replies with internal server error (500)",
+			"ServerError",
+			false,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setUpMock(tt.scenario)
+			defer ts.Close()
+			testURL, _ := url.Parse(ts.URL)
+
+			got, err := IsOnline(*testURL)
+			if got != tt.hostOk {
+				t.Errorf("IsOnline(%q) got = %v, want %v", testURL.String(), got, tt.hostOk)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsOnline(%q) error = %v, wantErr %v", testURL.String(), err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_IsOnline_MissingHost(t *testing.T) {
+	testURL, _ := url.Parse("https://does-not-exist.romie-gr.romie.com")
+
+	hostOk, err := IsOnline(*testURL)
+	if hostOk != false {
+		t.Errorf("IsOnline(%q) got = %v, want %v", testURL.String(), hostOk, false)
+	}
+
+	if (err != nil) != true {
+		t.Errorf("IsOnline(%q) error = %v, wantErr %v", testURL.String(), err, true)
+	}
+}


### PR DESCRIPTION
Adds utility `IsOnline` that checks if URL is accessible.
It will mark a host OK, if `200 <= HTTP Code < 300`.

Signature is reverted compared to the ticket description, because of linter error.

Closes #96