### PR TITLE
fix: Remove undeletable file testcase

### DIFF
--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -8,8 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/libopenstorage/openstorage/pkg/chattr"
 )
 
 var (
@@ -19,7 +17,6 @@ var (
 	nonExistingFile   = "./testdata/a-folder-that-exists/missing-file.txt"
 	nonWritableDir    = "./testdata/non-writable-dir"
 	fileToDelete      = "./testdata/a-folder-that-exists/a-file-to-be-deleted.txt"
-	fileNotToDelete   = "./testdata/a-folder-that-exists/a-file-not-to-be-deleted.txt"
 )
 
 func ExampleFolderExists() {
@@ -140,19 +137,8 @@ func ExampleRemoveFile() {
 	// Output: File deleted
 }
 
-func removeCleanup() {
-	err := chattr.RemoveImmutable(fileNotToDelete)
-	if err != nil {
-		log.Fatalf("Cannot remove immutable file %s", err)
-	}
-}
-
 func TestRemoveFile(t *testing.T) {
 	_ = CreateFile(fileToDelete)
-
-	createImmutableFile(fileNotToDelete)
-
-	defer removeCleanup()
 
 	tests := []struct {
 		name    string
@@ -172,11 +158,6 @@ func TestRemoveFile(t *testing.T) {
 		{
 			"Returns err when asked to delete file that does not exist",
 			nonExistingFile,
-			true,
-		},
-		{
-			"Returns err if asked to delete file that cannot be deleted ",
-			fileNotToDelete,
 			true,
 		},
 		{
@@ -269,11 +250,5 @@ func TestCreateFile(t *testing.T) {
 func skipWindowsNonWritableDirScenario(t *testing.T, file string, scenarioName string) {
 	if strings.Contains(file, filepath.Base(nonWritableDir)) && runtime.GOOS == "windows" {
 		t.Skipf("Skip %q test in windows", scenarioName)
-	}
-}
-
-func createImmutableFile(file string) {
-	if err := chattr.AddImmutable(file); err != nil {
-		log.Fatalf("Cannot create immutable file %s", err)
 	}
 }


### PR DESCRIPTION
The testcase that (wrongly) covered "deleting a file that cannot be deleted by RemoveFile()" cannot be implemented correctly.

* The approach where the file is to be made immutable (even when actually creating a file :P) by using the `chattr` library does not work. This is because the chattr operation (the call to `/usr/bin/chattr`)  is not permitted for a regular user, so  `chattr.AddImmutable(file)` will always return an error.

* The approach where the file permissions are modified using `os.Chmod` in order to make it undeletable does not work. Even with 000 file permissions, `os.Remove(file)` will delete the file. When removing such a file from terminal we are met with the promt `remove write-protected regular file?`. This of course does not affect the outcome of `os.Remove` which always deletes the file despite the removed write permissions.

So given that the testcase cannot be implemented, I have removed it.